### PR TITLE
Fix logged in player count stat

### DIFF
--- a/get_owencraft_stats.php
+++ b/get_owencraft_stats.php
@@ -86,7 +86,8 @@
 
     $msg = "Grabbing count of logged in players...";
     $logger->logMsg($msg, 0);
-    $player_count = count(getLoggedInPlayers());
+    $logged_in_players = getLoggedInPlayers(); // this gets the full array, meaning keys and values
+    $player_count = count($logged_in_players); // count number of keys to get the player count
     $contents = "owencraft_misc_counts{objective=\"logged_in_players\"} " . $player_count . "\n";
     file_put_contents($prom->tmp_file, $contents, FILE_APPEND | LOCK_EX);
 

--- a/mcrcon.class.php
+++ b/mcrcon.class.php
@@ -36,7 +36,16 @@
         private function getPlayers(string $players) {
 
             if(preg_match("/^.*?online\:\s+(.*)$/", $players, $matches)) {
-                unset($matches[0]);
+                unset($matches[0]); // this is set to remove the entire string
+                foreach($matches as $match) {
+                    // the string in the $match variable may appear to be empty
+                    // but it is only visually empty and is actually 4 bytes in length
+                    // according to the strlen() function. so doing an empty(), is_null(),
+                    // or $match !== "" will not work here
+                    if(strlen($match) > 4) {
+                        $loggedIn[] = $match; // update the array with the logged in user
+                    }
+                }
             } else {
                 $matches = array();
             }


### PR DESCRIPTION
- fixed the getPlayers() method in the mcrcon class to only append real player names to the returned array, which will correct the player count error
- updated the get_owencraft_stats.php script to separate out the returned array from the count of keys in the array and added some comments to signify this change