### PR TITLE
Add logged in player names as a stat

### DIFF
--- a/get_owencraft_stats.php
+++ b/get_owencraft_stats.php
@@ -91,6 +91,17 @@
     $contents = "owencraft_misc_counts{objective=\"logged_in_players\"} " . $player_count . "\n";
     file_put_contents($prom->tmp_file, $contents, FILE_APPEND | LOCK_EX);
 
+    $msg = "Grabbing names of any logged in players...";
+    $logger->logMsg($msg, 0);
+    foreach($oc->players as $player) {
+        if(in_array($player["name"], $logged_in_players)) {
+            $contents = "owencraft_misc_counts{objective=\"player_logged_in\",player=\"" . $player["name"] . "\"} 1\n";
+        } else {
+            $contents = "owencraft_misc_counts{objective=\"player_logged_in\",player=\"" . $player["name"] . "\"} 0\n";
+        }
+        file_put_contents($prom->tmp_file, $contents, FILE_APPEND | LOCK_EX);
+    }
+    
     $msg = "Moving " . $prom->tmp_file . " to " . $prom->store_file . "...";
     $logger->logMsg($msg, 0);
 

--- a/mcrcon.class.php
+++ b/mcrcon.class.php
@@ -35,6 +35,7 @@
 
         private function getPlayers(string $players) {
 
+            $loggedIn = array();
             if(preg_match("/^.*?online\:\s+(.*)$/", $players, $matches)) {
                 unset($matches[0]); // this is set to remove the entire string
                 foreach($matches as $match) {
@@ -46,11 +47,9 @@
                         $loggedIn[] = $match; // update the array with the logged in user
                     }
                 }
-            } else {
-                $matches = array();
             }
 
-            return $matches;
+            return $loggedIn;
 
         }
 


### PR DESCRIPTION
- updated get_owencraft_stats.php to loop through the players object built by the ocstats class and compares the names of registered players against the names of any players found in the listPlayers() method from the mcrcon class
- fixed some typos in the mcrcon class