### PR TITLE
Fix 1.19.3 server stats not showing

### DIFF
--- a/get_owencraft_stats.php
+++ b/get_owencraft_stats.php
@@ -79,9 +79,11 @@
     $msg = "Grabbing server version...";
     $logger->logMsg($msg, 0);
     $server_version = getMinecraftServerVersion($server_jar);
+    $msg = "Got server version: {$server_version}!";
+    $logger->logMsg($msg, 0);
     $obj = "# TYPE owencraft_misc_counts gauge\n";
     file_put_contents($prom->tmp_file, $obj, FILE_APPEND | LOCK_EX);
-    $contents = "owencraft_misc_counts{objective=\"server_version\"} " . $server_version . "\n";
+    $contents = "owencraft_misc_counts{objective=\"server_version\", version=\"{$server_version}\"} 1\n";
     file_put_contents($prom->tmp_file, $contents, FILE_APPEND | LOCK_EX);
 
     $msg = "Grabbing count of logged in players...";


### PR DESCRIPTION
- updated the server_version output to be a label instead of the value
- and added an extra log message